### PR TITLE
debian: add polkit for trixie

### DIFF
--- a/images/debian.yaml
+++ b/images/debian.yaml
@@ -1217,11 +1217,19 @@ packages:
     architectures:
     - amd64
     - arm64
-    types:
-    - vm
     releases:
     - buster
     - bullseye
+
+  - packages:
+    - polkit
+    action: install
+    architectures:
+    - amd64
+    - arm64
+    releases:
+    - trixie
+    - sid
 
   - packages:
     - pkexec
@@ -1229,8 +1237,6 @@ packages:
     architectures:
     - amd64
     - arm64
-    types:
-    - vm
     releases:
     - bookworm
     - trixie


### PR DESCRIPTION
- polkit is needed for systemd-networkd to set hostnames
- this operation can happen in an Incus container if `cloud-init.network-config` is set.

Within any incus container by default, based on `images:debian/trixie/cloud`, the following error can be seen:

```
$ journalctl -u systemd-networkd
Jan 28 19:51:40 nettest systemd-networkd[189]: eth1: Gained IPv6LL
Jan 28 19:51:40 nettest systemd-networkd[189]: eth2: Gained IPv6LL
Jan 28 19:51:40 nettest systemd-networkd[189]: eth2: DHCPv4 address 192.168.254.28/24, gateway 192.168.254.1 acquired from 192.168.254.1
Jan 28 19:51:43 nettest systemd-networkd[189]: Could not set hostname: Access denied
```

Looks like polkit needs to be added back for trixie. Once the package is installed the error is gone.

IMHO this does need to be in place for both container and VM as in both scenarios one may have to configure network.